### PR TITLE
URL parameter "APPID" should be lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,7 +395,7 @@ WeatherAccessory.prototype =
                 url += "forecast";
             }
 
-            url += "?APPID=" + this.apikey + "&units=" + this.unit + "&";
+            url += "?appid=" + this.apikey + "&units=" + this.unit + "&";
             if (this.locationByCity) {
                 url += "q=" + this.locationByCity;
             } else if (this.locationById) {


### PR DESCRIPTION
I was getting the error below and changing the `APPID` to `appid` fixed it. OpenWeather docs suggest lowercase: https://openweathermap.org/guide#api.

`body: '{"cod":401, "message": "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info."}'`